### PR TITLE
Add channel-aware updater wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master, dev]
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    name: shellcheck + tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends shellcheck
+
+      - name: Shell syntax
+        run: |
+          bash -n install.sh
+          bash -n update-webconfig.sh
+          bash -n helpers/bg-update.sh
+          bash -n helpers/update-channel.sh
+          bash -n test/update-channel-test.sh
+
+      - name: Shellcheck changed scripts
+        run: |
+          shellcheck -S warning \
+            install.sh \
+            update-webconfig.sh \
+            helpers/bg-update.sh \
+            helpers/update-channel.sh \
+            test/update-channel-test.sh
+
+      - name: Run channel tests
+        run: bash test/update-channel-test.sh

--- a/helpers/bg-update.sh
+++ b/helpers/bg-update.sh
@@ -1,15 +1,29 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd)"
+CHANNEL_HELPER="$SCRIPT_DIR/update-channel.sh"
+if [[ ! -f "$CHANNEL_HELPER" ]]; then
+    CHANNEL_HELPER="/airplanes/webconfig/helpers/update-channel.sh"
+fi
+
+# shellcheck source=/dev/null
+source "$CHANNEL_HELPER"
+airplanes_webconfig_load_installed_channel "/airplanes/webconfig/channel.env" "$SCRIPT_DIR"
+
 log=/airplanes/airplanes-update.log
-rm -f $log
+rm -f "$log"
 exec &> >(tee -a "$log")
 
 export DEBIAN_FRONTEND=noninteractive
 apt update
 #apt upgrade -y
 
-bash -c "$(wget -nv -O - https://raw.githubusercontent.com/airplanes-live/airplanes-update/main/update-airplanes.sh)"  >> /tmp/web_display_log
-bash -c "$(wget -nv -O - https://raw.githubusercontent.com/airplanes-live/airplanes-webconfig/master/update-webconfig.sh)"  >> /tmp/web_display_log
+AIRPLANES_UPDATE_BRANCH="$AIRPLANES_UPDATE_BRANCH" \
+AIRPLANES_FEED_BRANCH="$AIRPLANES_FEED_BRANCH" \
+    bash -c "$(wget -nv -O - "$(airplanes_update_script_url)")" >> /tmp/web_display_log
+
+AIRPLANES_WEBCONFIG_BRANCH="$AIRPLANES_WEBCONFIG_BRANCH" \
+    bash -c "$(wget -nv -O - "$(airplanes_webconfig_update_script_url)")" >> /tmp/web_display_log
 
 echo "rebooting..."
 sleep 5

--- a/helpers/update-channel.sh
+++ b/helpers/update-channel.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+airplanes_webconfig_git_branch() {
+    local dir="${1:-$(pwd)}"
+    if command -v git &>/dev/null && git -C "$dir" rev-parse --is-inside-work-tree &>/dev/null; then
+        git -C "$dir" symbolic-ref --quiet --short HEAD 2>/dev/null || true
+    fi
+}
+
+airplanes_webconfig_detect_channel() {
+    local dir="${1:-$(pwd)}"
+    local branch
+    branch="$(airplanes_webconfig_git_branch "$dir")"
+    if [[ "$branch" == "dev" ]]; then
+        printf '%s\n' "dev"
+    else
+        printf '%s\n' "main"
+    fi
+}
+
+airplanes_webconfig_apply_channel_defaults() {
+    local dir="${1:-$(pwd)}"
+    local channel="${AIRPLANES_CHANNEL:-${AIRPLANES_WEBCONFIG_CHANNEL_DEFAULT:-}}"
+    local update_branch feed_branch webconfig_branch
+
+    if [[ -z "$channel" ]]; then
+        channel="$(airplanes_webconfig_detect_channel "$dir")"
+    fi
+
+    case "$channel" in
+        dev)
+            channel="dev"
+            update_branch="dev"
+            feed_branch="dev"
+            webconfig_branch="dev"
+            ;;
+        *)
+            channel="main"
+            update_branch="main"
+            feed_branch="main"
+            webconfig_branch="master"
+            ;;
+    esac
+
+    AIRPLANES_CHANNEL="$channel"
+    AIRPLANES_UPDATE_BRANCH="${AIRPLANES_UPDATE_BRANCH:-$update_branch}"
+    AIRPLANES_FEED_BRANCH="${AIRPLANES_FEED_BRANCH:-$feed_branch}"
+    AIRPLANES_WEBCONFIG_BRANCH="${AIRPLANES_WEBCONFIG_BRANCH:-$webconfig_branch}"
+
+    export AIRPLANES_CHANNEL AIRPLANES_UPDATE_BRANCH AIRPLANES_FEED_BRANCH AIRPLANES_WEBCONFIG_BRANCH
+}
+
+airplanes_webconfig_load_installed_channel() {
+    local env_file="${1:-/airplanes/webconfig/channel.env}"
+    local dir="${2:-$(pwd)}"
+
+    if [[ -f "$env_file" ]]; then
+        # shellcheck source=/dev/null
+        source "$env_file"
+    fi
+    airplanes_webconfig_apply_channel_defaults "$dir"
+}
+
+airplanes_webconfig_write_channel_env() {
+    local env_file="$1"
+    mkdir -p "$(dirname "$env_file")"
+    cat > "$env_file" <<EOF
+AIRPLANES_WEBCONFIG_CHANNEL_DEFAULT="$AIRPLANES_CHANNEL"
+EOF
+}
+
+airplanes_update_script_url() {
+    local base="${AIRPLANES_UPDATE_RAW_BASE:-https://raw.githubusercontent.com/airplanes-live/airplanes-update}"
+    printf '%s/%s/update-airplanes.sh\n' "${base%/}" "$AIRPLANES_UPDATE_BRANCH"
+}
+
+airplanes_webconfig_update_script_url() {
+    local base="${AIRPLANES_WEBCONFIG_RAW_BASE:-https://raw.githubusercontent.com/airplanes-live/airplanes-webconfig}"
+    printf '%s/%s/update-webconfig.sh\n' "${base%/}" "$AIRPLANES_WEBCONFIG_BRANCH"
+}

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-if [ $(id -u) -ne 0 ]; then
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+# shellcheck source=helpers/update-channel.sh
+source "$SCRIPT_DIR/helpers/update-channel.sh"
+airplanes_webconfig_apply_channel_defaults "$SCRIPT_DIR"
+
+if [[ "$(id -u)" -ne 0 ]]; then
   echo -e "This script must be run as root. \n"
   exit 1
 fi
@@ -33,17 +39,18 @@ done
 
 ipath=/airplanes/webconfig
 
-mkdir -p $ipath
-cp airplanes-config.txt.webtemplate webconfig.sh leds.sh sanitize-uuid.sh $ipath
+mkdir -p "$ipath"
+cp airplanes-config.txt.webtemplate webconfig.sh leds.sh sanitize-uuid.sh "$ipath"
 cp ./webconfig.service /etc/systemd/system/
 cp ./leds.service /etc/systemd/system/
 rm -f /var/www/html/index.htm*
 cp -r ./html/* /var/www/html
 cp ./dnsmasq.conf /etc/
 
-rm -rf $ipath/helpers
-cp -r -T ./helpers $ipath/helpers
-chmod a+x $ipath/helpers/*.sh
+rm -rf "$ipath/helpers"
+cp -r -T ./helpers "$ipath/helpers"
+chmod a+x "$ipath"/helpers/*.sh
+airplanes_webconfig_write_channel_env "$ipath/channel.env"
 cp ./010_www-data /etc/sudoers.d/
 for file in helpers/*.sh; do
     echo "www-data ALL = NOPASSWD: /airplanes/webconfig/$file" >> /etc/sudoers.d/010_www-data
@@ -51,9 +58,9 @@ done
 
 rm -rf /airplanes/update
 mkdir -p /airplanes
-git clone --depth 1 https://github.com/airplanes-live/airplanes-update.git /airplanes/update
+git clone --depth 1 --single-branch --branch "$AIRPLANES_UPDATE_BRANCH" https://github.com/airplanes-live/airplanes-update.git /airplanes/update
 
-pushd /airplanes/update/
+pushd /airplanes/update/ >/dev/null || exit
 cp -v -T boot-configs/wpa_supplicant.conf /boot/wpa_supplicant.conf.bak
 # always copy over this file ^ ^ ^
 if [[ "$1" != "dont_reset_config" ]]; then
@@ -64,7 +71,7 @@ if [[ "$1" != "dont_reset_config" ]]; then
     echo -e "\n UNLOCKING UNIT UNTIL FIRST CONFIG"
     touch /boot/unlock
 fi
-popd
+popd >/dev/null || exit
 
 # We do not use hostapd. Setup network is open.
 systemctl disable hostapd &>/dev/null || true

--- a/test/update-channel-test.sh
+++ b/test/update-channel-test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${AIRPLANES_WEBCONFIG_TEST_ROOT:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
+WORK_DIR="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+# shellcheck source=helpers/update-channel.sh
+source "$REPO_ROOT/helpers/update-channel.sh"
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local label="$3"
+
+    [[ "$actual" == "$expected" ]] || fail "$label: expected '$expected', got '$actual'"
+}
+
+reset_channel_env() {
+    unset AIRPLANES_CHANNEL
+    unset AIRPLANES_WEBCONFIG_CHANNEL_DEFAULT
+    unset AIRPLANES_UPDATE_BRANCH
+    unset AIRPLANES_FEED_BRANCH
+    unset AIRPLANES_WEBCONFIG_BRANCH
+    unset AIRPLANES_UPDATE_RAW_BASE
+    unset AIRPLANES_WEBCONFIG_RAW_BASE
+}
+
+make_checkout() {
+    local dir="$1"
+    local branch="$2"
+
+    mkdir -p "$dir"
+    git -C "$dir" init -q -b "$branch"
+    git -C "$dir" config user.email "webconfig-channel@example.invalid"
+    git -C "$dir" config user.name "Webconfig Channel Test"
+    printf '%s\n' "$branch" > "$dir/.fixture"
+    git -C "$dir" add .fixture
+    git -C "$dir" commit -q -m "channel fixture"
+}
+
+assert_dev_defaults() {
+    assert_eq "dev" "$AIRPLANES_CHANNEL" "channel"
+    assert_eq "dev" "$AIRPLANES_UPDATE_BRANCH" "update branch"
+    assert_eq "dev" "$AIRPLANES_FEED_BRANCH" "feed branch"
+    assert_eq "dev" "$AIRPLANES_WEBCONFIG_BRANCH" "webconfig branch"
+    assert_eq "https://raw.githubusercontent.com/airplanes-live/airplanes-update/dev/update-airplanes.sh" \
+        "$(airplanes_update_script_url)" "update raw URL"
+    assert_eq "https://raw.githubusercontent.com/airplanes-live/airplanes-webconfig/dev/update-webconfig.sh" \
+        "$(airplanes_webconfig_update_script_url)" "webconfig raw URL"
+}
+
+assert_main_defaults() {
+    assert_eq "main" "$AIRPLANES_CHANNEL" "channel"
+    assert_eq "main" "$AIRPLANES_UPDATE_BRANCH" "update branch"
+    assert_eq "main" "$AIRPLANES_FEED_BRANCH" "feed branch"
+    assert_eq "master" "$AIRPLANES_WEBCONFIG_BRANCH" "webconfig branch"
+    assert_eq "https://raw.githubusercontent.com/airplanes-live/airplanes-update/main/update-airplanes.sh" \
+        "$(airplanes_update_script_url)" "update raw URL"
+    assert_eq "https://raw.githubusercontent.com/airplanes-live/airplanes-webconfig/master/update-webconfig.sh" \
+        "$(airplanes_webconfig_update_script_url)" "webconfig raw URL"
+}
+
+test_dev_checkout_defaults_to_dev() {
+    local checkout="$WORK_DIR/dev-checkout"
+    make_checkout "$checkout" dev
+    reset_channel_env
+
+    airplanes_webconfig_apply_channel_defaults "$checkout"
+    assert_dev_defaults
+    echo "dev checkout defaults passed"
+}
+
+test_main_checkout_defaults_to_main() {
+    local checkout="$WORK_DIR/main-checkout"
+    make_checkout "$checkout" master
+    reset_channel_env
+
+    airplanes_webconfig_apply_channel_defaults "$checkout"
+    assert_main_defaults
+    echo "main checkout defaults passed"
+}
+
+test_env_overrides_win() {
+    local checkout="$WORK_DIR/override-checkout"
+    make_checkout "$checkout" dev
+    reset_channel_env
+
+    AIRPLANES_CHANNEL=main
+    AIRPLANES_UPDATE_BRANCH=custom-update
+    AIRPLANES_FEED_BRANCH=custom-feed
+    AIRPLANES_WEBCONFIG_BRANCH=custom-webconfig
+    airplanes_webconfig_apply_channel_defaults "$checkout"
+
+    assert_eq "main" "$AIRPLANES_CHANNEL" "channel override"
+    assert_eq "custom-update" "$AIRPLANES_UPDATE_BRANCH" "update override"
+    assert_eq "custom-feed" "$AIRPLANES_FEED_BRANCH" "feed override"
+    assert_eq "custom-webconfig" "$AIRPLANES_WEBCONFIG_BRANCH" "webconfig override"
+    echo "env override defaults passed"
+}
+
+test_installed_channel_env_is_loaded_without_git() {
+    local checkout="$WORK_DIR/dev-installed-source"
+    local raw_dir="$WORK_DIR/raw-installed-helper"
+    local env_file="$WORK_DIR/channel.env"
+    make_checkout "$checkout" dev
+    mkdir -p "$raw_dir"
+    reset_channel_env
+
+    airplanes_webconfig_apply_channel_defaults "$checkout"
+    airplanes_webconfig_write_channel_env "$env_file"
+
+    reset_channel_env
+    airplanes_webconfig_load_installed_channel "$env_file" "$raw_dir"
+    assert_dev_defaults
+    echo "installed channel env load passed"
+}
+
+main() {
+    test_dev_checkout_defaults_to_dev
+    test_main_checkout_defaults_to_main
+    test_env_overrides_win
+    test_installed_channel_env_is_loaded_without_git
+    echo "webconfig update channel tests passed"
+}
+
+main "$@"

--- a/update-webconfig.sh
+++ b/update-webconfig.sh
@@ -3,6 +3,16 @@
 set -e
 trap 'echo "[ERROR] Error in line $LINENO when executing: $BASH_COMMAND"' ERR
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd)"
+if [[ -f "$SCRIPT_DIR/helpers/update-channel.sh" ]]; then
+    # shellcheck source=helpers/update-channel.sh
+    source "$SCRIPT_DIR/helpers/update-channel.sh"
+    airplanes_webconfig_apply_channel_defaults "$SCRIPT_DIR"
+fi
+
+WEBCONFIG_REPO="${AIRPLANES_WEBCONFIG_REPO:-https://github.com/airplanes-live/airplanes-webconfig.git}"
+WEBCONFIG_BRANCH="${AIRPLANES_WEBCONFIG_BRANCH:-master}"
+
 # in case /var/log is full ... delete some logs
 echo test > /var/log/.test 2>/dev/null || rm -f /var/log/*.log
 
@@ -18,15 +28,15 @@ aptInstall git
 cd /tmp
 updir=/tmp/update-webconfig
 
-rm -rf $updir
-git clone --depth 1 https://github.com/airplanes-live/airplanes-webconfig.git $updir
+rm -rf "$updir"
+git clone --depth 1 --single-branch --branch "$WEBCONFIG_BRANCH" "$WEBCONFIG_REPO" "$updir"
 
-cd $updir
+cd "$updir"
 bash install.sh dont_reset_config
 
 
 cd /tmp
-rm -rf $updir
+rm -rf "$updir"
 
 echo "8.3.$(date '+%y%m%d')" > /boot/airplanes-version-webconfig
 


### PR DESCRIPTION
## Summary

- Add a small channel helper so dev webconfig installs and updates dev components, while stable continues to use update/main, feed/main, and webconfig/master.
- Persist the installed channel in /airplanes/webconfig/channel.env so copied update helpers keep using the same channel.
- Update installer and background updater paths to pass the correct updater/feed/webconfig branches.
- Add CI with shell syntax, shellcheck for the touched scripts, and channel mapping tests.

## Tests

- bash test/update-channel-test.sh
- bash -n install.sh update-webconfig.sh helpers/bg-update.sh helpers/update-channel.sh test/update-channel-test.sh
- shellcheck -S warning install.sh update-webconfig.sh helpers/bg-update.sh helpers/update-channel.sh test/update-channel-test.sh