### PR TITLE
Migrate legacy USER schema to MLAT_USER+MLAT_ENABLED on save

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,11 @@ jobs:
           bash -n update-webconfig.sh
           bash -n helpers/bg-update.sh
           bash -n helpers/update-channel.sh
+          bash -n helpers/migrate-config.sh
+          bash -n helpers/install-adsbconfig.sh
+          bash -n helpers/restart-services.sh
           bash -n test/update-channel-test.sh
+          bash -n test/migrate-config-test.sh
 
       - name: Shellcheck changed scripts
         run: |
@@ -39,7 +43,14 @@ jobs:
             update-webconfig.sh \
             helpers/bg-update.sh \
             helpers/update-channel.sh \
-            test/update-channel-test.sh
+            helpers/migrate-config.sh \
+            helpers/install-adsbconfig.sh \
+            helpers/restart-services.sh \
+            test/update-channel-test.sh \
+            test/migrate-config-test.sh
 
       - name: Run channel tests
         run: bash test/update-channel-test.sh
+
+      - name: Run migrate-config tests
+        run: bash test/migrate-config-test.sh

--- a/helpers/install-adsbconfig.sh
+++ b/helpers/install-adsbconfig.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
-
-cp /tmp/webconfig/airplanes-config.txt /boot/airplanes-config.txt
-
+# Installs the PHP-rendered airplanes-config.txt into /boot, applying the
+# MLAT_USER schema migration before publishing. Wrapped under flock so
+# restart-services.sh cannot read a half-migrated file. The temp file is
+# adjacent to /boot/airplanes-config.txt so readers never see a
+# legacy-only intermediate state at the canonical path.
+set -euo pipefail
+exec flock /var/lock/airplanes-config.lock env AIRPLANES_CONFIG_LOCK_HELD=1 bash -c '
+    set -euo pipefail
+    tmp="$(mktemp /boot/airplanes-config.txt.XXXXXX)"
+    trap "rm -f \"$tmp\"" EXIT
+    cp /tmp/webconfig/airplanes-config.txt "$tmp"
+    /airplanes/webconfig/helpers/migrate-config.sh "$tmp"
+    chmod --reference=/boot/airplanes-config.txt "$tmp" 2>/dev/null || chmod 0644 "$tmp"
+    mv -f "$tmp" /boot/airplanes-config.txt
+    trap - EXIT
+'

--- a/helpers/migrate-config.sh
+++ b/helpers/migrate-config.sh
@@ -26,6 +26,9 @@
 #     restricts to [A-Za-z0-9_.-]).
 #   - When USER is absent, the file is treated as already on the new
 #     schema and not touched.
+#   - Empty USER (USER="") is treated as "opted in, no name" and
+#     produces MLAT_USER="Anonymous" / MLAT_ENABLED=true, matching the
+#     defaults in feed/configure.sh and feed/scripts/apl-feed/mlat.sh.
 #
 # Env vars:
 #   AIRPLANES_CONFIG_LOCK_HELD=1   Skip flock (caller already holds it).
@@ -128,6 +131,14 @@ derive_mlat_from_user() {
         0|disable)
             MLAT_USER_OUT=""
             MLAT_ENABLED_OUT="false"
+            ;;
+        '')
+            # Empty USER → "Anonymous" so the daemon's strict-fail on
+            # empty MLAT_USER + MLAT_ENABLED=true never fires. Mirrors
+            # the writer-side defaults in feed/configure.sh and
+            # feed/scripts/apl-feed/mlat.sh.
+            MLAT_USER_OUT="Anonymous"
+            MLAT_ENABLED_OUT="true"
             ;;
         *)
             MLAT_USER_OUT="$user"

--- a/helpers/migrate-config.sh
+++ b/helpers/migrate-config.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# migrate-config.sh - Migrate legacy USER= schema in airplanes-config.txt
+# to the split MLAT_USER + MLAT_ENABLED schema expected by the new feed
+# daemons in airplanes-live/feed.
+#
+# Canonical home: airplanes-live/airplanes-webconfig:helpers/migrate-config.sh
+# Vendored byte-equivalent copy: airplanes-live/airplanes-update:
+#     skeleton/usr/local/lib/airplanes-update/migrate-config.sh
+# Drift between the two is enforced by a CI test in airplanes-update.
+#
+# Usage:
+#   migrate-config.sh <path>            apply migration in-place
+#   migrate-config.sh --version         print MIGRATOR_VERSION and exit
+#
+# Behavior:
+#   - Idempotent. Byte-compares the rendered output against the input;
+#     only mv's if different (mtime unchanged on no-op).
+#   - Never sources the file. Sourcing would execute user-supplied shell.
+#   - Atomic via mktemp adjacent + mv.
+#   - On first migration of a legacy file (USER present, MLAT_USER absent)
+#     writes a `.pre-mlat-split` backup. Idempotent: never overwritten.
+#   - When USER is present it is authoritative: any stale MLAT_USER /
+#     MLAT_ENABLED lines are stripped and re-derived. The USER= line is
+#     re-emitted in `USER="<escaped>"` form for shell-meta safety
+#     (defense for hand-edited files; PHP webconfig sanitize already
+#     restricts to [A-Za-z0-9_.-]).
+#   - When USER is absent, the file is treated as already on the new
+#     schema and not touched.
+#
+# Env vars:
+#   AIRPLANES_CONFIG_LOCK_HELD=1   Skip flock (caller already holds it).
+#                                  Used by install-adsbconfig.sh wrapper.
+
+set -euo pipefail
+
+MIGRATOR_VERSION=1
+LOCK_FILE="/var/lock/airplanes-config.lock"
+
+# Extract the last-wins value of KEY from FILE without sourcing it.
+#
+# Returns:
+#   0  KEY present (value printed to stdout; may be empty)
+#   1  KEY absent
+#   2  KEY present but malformed (e.g. unterminated quote)
+extract_key() {
+    local file="$1" key="$2"
+    local line raw found=0
+    raw=""
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%$'\r'}"
+        [[ -z "$line" || "${line:0:1}" == "#" ]] && continue
+        case "$line" in
+            "${key}="*)
+                raw="${line#"${key}="}"
+                found=1
+                ;;
+        esac
+    done < "$file"
+
+    if (( ! found )); then
+        return 1
+    fi
+
+    case "$raw" in
+        '"'*)
+            # Double-quoted: handle \\, \", \$, \` escapes; reject if
+            # closing quote is missing.
+            local result="" i len=${#raw} escaped=0 closed=0 c
+            for (( i=1; i<len; i++ )); do
+                c="${raw:$i:1}"
+                if (( escaped )); then
+                    result+="$c"
+                    escaped=0
+                elif [[ "$c" == '\' ]]; then
+                    escaped=1
+                elif [[ "$c" == '"' ]]; then
+                    closed=1
+                    break
+                else
+                    result+="$c"
+                fi
+            done
+            if (( ! closed )); then
+                printf 'migrate-config.sh: %s: malformed double-quoted value for %s=\n' "$file" "$key" >&2
+                return 2
+            fi
+            printf '%s' "$result"
+            ;;
+        "'"*)
+            # Single-quoted: no escapes; reject if closing quote missing.
+            local body="${raw#\'}"
+            case "$body" in
+                *"'"*)
+                    body="${body%%\'*}"
+                    printf '%s' "$body"
+                    ;;
+                *)
+                    printf 'migrate-config.sh: %s: malformed single-quoted value for %s=\n' "$file" "$key" >&2
+                    return 2
+                    ;;
+            esac
+            ;;
+        *)
+            # Unquoted: ends at first whitespace (trailing comments must
+            # be space-separated per shell parsing).
+            printf '%s' "${raw%%[[:space:]]*}"
+            ;;
+    esac
+    return 0
+}
+
+# Escape a literal value for safe inclusion in `KEY="<value>"` form.
+# Order matters: backslash first so subsequent escapes don't double-up.
+escape_for_double_quoted() {
+    local v="$1"
+    v="${v//\\/\\\\}"
+    v="${v//\$/\\\$}"
+    v="${v//\`/\\\`}"
+    v="${v//\"/\\\"}"
+    printf '%s' "$v"
+}
+
+# Decide MLAT_USER / MLAT_ENABLED from a USER value per migration rules.
+# Sets caller-scope variables MLAT_USER_OUT and MLAT_ENABLED_OUT.
+derive_mlat_from_user() {
+    local user="$1"
+    case "$user" in
+        0|disable)
+            MLAT_USER_OUT=""
+            MLAT_ENABLED_OUT="false"
+            ;;
+        *)
+            MLAT_USER_OUT="$user"
+            MLAT_ENABLED_OUT="true"
+            ;;
+    esac
+}
+
+# Run the migration on $path. Caller is responsible for the lock.
+do_migrate() {
+    local path="$1"
+    local backup_path="${path}.pre-mlat-split"
+
+    local user_value="" user_present=0 mlat_user_present=0 rc
+
+    if user_value="$(extract_key "$path" USER)"; then
+        user_present=1
+    else
+        rc=$?
+        case "$rc" in
+            1) user_present=0 ;;
+            2) exit 2 ;;
+            *) exit "$rc" ;;
+        esac
+    fi
+
+    if extract_key "$path" MLAT_USER >/dev/null; then
+        mlat_user_present=1
+    else
+        rc=$?
+        case "$rc" in
+            1) mlat_user_present=0 ;;
+            2) exit 2 ;;
+            *) exit "$rc" ;;
+        esac
+    fi
+
+    # MLAT_ENABLED malformed is also a hard fail, even though we don't
+    # use its value here (it gets re-derived).
+    if extract_key "$path" MLAT_ENABLED >/dev/null; then
+        :
+    else
+        rc=$?
+        case "$rc" in
+            1) : ;;
+            2) exit 2 ;;
+            *) exit "$rc" ;;
+        esac
+    fi
+
+    # USER absent → file is already on new schema (or has no schema).
+    # Don't touch it. mtime stays unchanged.
+    if (( ! user_present )); then
+        return 0
+    fi
+
+    # USER present: migrate. USER is authoritative; any stale MLAT_USER
+    # / MLAT_ENABLED is stripped and re-derived.
+    local MLAT_USER_OUT="" MLAT_ENABLED_OUT=""
+    derive_mlat_from_user "$user_value"
+
+    local user_escaped mlat_user_escaped
+    user_escaped="$(escape_for_double_quoted "$user_value")"
+    mlat_user_escaped="$(escape_for_double_quoted "$MLAT_USER_OUT")"
+
+    # Backup once on first transition out of pure-legacy (USER present,
+    # MLAT_USER absent). Never overwritten.
+    if [[ ! -f "$backup_path" ]] && (( ! mlat_user_present )); then
+        cp -fp "$path" "$backup_path"
+    fi
+
+    # Render desired output to an adjacent temp file. The first USER=
+    # line becomes the anchor: re-emitted in normalized form, immediately
+    # followed by MLAT_USER and MLAT_ENABLED. Subsequent USER= lines and
+    # any existing MLAT_USER= / MLAT_ENABLED= lines are dropped.
+    local tmp
+    tmp="$(mktemp "${path}.XXXXXX")"
+    # shellcheck disable=SC2064
+    trap "rm -f '$tmp'" EXIT
+
+    {
+        local line trimmed user_seen=0
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            trimmed="${line%$'\r'}"
+            case "$trimmed" in
+                'USER='*)
+                    if (( ! user_seen )); then
+                        printf 'USER="%s"\n' "$user_escaped"
+                        printf 'MLAT_USER="%s"\n' "$mlat_user_escaped"
+                        printf 'MLAT_ENABLED=%s\n' "$MLAT_ENABLED_OUT"
+                        user_seen=1
+                    fi
+                    ;;
+                'MLAT_USER='*|'MLAT_ENABLED='*)
+                    : # drop; will be re-emitted by the USER anchor
+                    ;;
+                *)
+                    printf '%s\n' "$line"
+                    ;;
+            esac
+        done < "$path"
+    } > "$tmp"
+
+    # Preserve mode and ownership. On vfat /boot ownership is meaningless,
+    # so chown failure is tolerated; chmod falls back to 0644.
+    chmod --reference="$path" "$tmp" 2>/dev/null || chmod 0644 "$tmp"
+    chown --reference="$path" "$tmp" 2>/dev/null || true
+
+    # Byte-compare. No-op when output is identical to input so mtime is
+    # preserved across idempotent re-runs.
+    if cmp -s "$path" "$tmp"; then
+        rm -f "$tmp"
+        trap - EXIT
+        return 0
+    fi
+
+    mv -f "$tmp" "$path"
+    trap - EXIT
+}
+
+main() {
+    if [[ "${1:-}" == "--version" ]]; then
+        printf 'migrate-config.sh version=%d\n' "$MIGRATOR_VERSION"
+        return 0
+    fi
+
+    local path="${1:-}"
+    if [[ -z "$path" ]]; then
+        echo "usage: migrate-config.sh <path>" >&2
+        return 2
+    fi
+
+    if [[ ! -f "$path" ]]; then
+        # Nothing to migrate. Don't fail — could be a fresh install
+        # where airplanes-config.txt hasn't been created yet.
+        return 0
+    fi
+
+    if [[ "${AIRPLANES_CONFIG_LOCK_HELD:-}" == "1" ]]; then
+        do_migrate "$path"
+        return
+    fi
+
+    mkdir -p "$(dirname "$LOCK_FILE")"
+    exec 9>"$LOCK_FILE"
+    flock 9
+    do_migrate "$path"
+}
+
+main "$@"

--- a/helpers/restart-services.sh
+++ b/helpers/restart-services.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
+# Restarts services that consume /boot/airplanes-config.txt. Held under the
+# same flock as install-adsbconfig.sh so a restart can never fire while a
+# save is mid-cp-or-mid-migrate.
 
-restartIfEnabled() {
-    # check if enabled
-    if systemctl is-enabled "$1" &>/dev/null; then
+set -euo pipefail
+
+exec flock /var/lock/airplanes-config.lock bash -c '
+    restartIfEnabled() {
+        if systemctl is-enabled "$1" &>/dev/null; then
             systemctl restart "$1"
-    fi
-}
+        fi
+    }
 
-systemctl restart webconfig
+    systemctl restart webconfig
 
-airplanes-first-run
+    airplanes-first-run
 
-services="readsb dump978-fa airplanes-978 airplanes-feed airplanes-mlat webconfig leds"
-for service in $services; do
-    restartIfEnabled $service
-done
-
+    services="readsb dump978-fa airplanes-978 airplanes-feed airplanes-mlat webconfig leds"
+    for service in $services; do
+        restartIfEnabled "$service"
+    done
+'

--- a/install.sh
+++ b/install.sh
@@ -73,6 +73,15 @@ if [[ "$1" != "dont_reset_config" ]]; then
 fi
 popd >/dev/null || exit
 
+# One-time migration of /boot/airplanes-config.txt to the new MLAT_USER
+# schema. Idempotent (byte-compares before rewriting). Runs AFTER the
+# boot-configs/* copy above so it sees the freshly-placed template if
+# one was just dropped. Safe on dont_reset_config installs too: the
+# existing airplanes-config.txt is what needs migrating.
+if [[ -f /boot/airplanes-config.txt ]]; then
+    /airplanes/webconfig/helpers/migrate-config.sh /boot/airplanes-config.txt
+fi
+
 # We do not use hostapd. Setup network is open.
 systemctl disable hostapd &>/dev/null || true
 systemctl enable webconfig

--- a/test/migrate-config-test.sh
+++ b/test/migrate-config-test.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Tests for helpers/migrate-config.sh — legacy USER → MLAT_USER+MLAT_ENABLED
+# migration on /boot/airplanes-config.txt.
+set -euo pipefail
+
+REPO_ROOT="${AIRPLANES_WEBCONFIG_TEST_ROOT:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
+MIGRATOR="$REPO_ROOT/helpers/migrate-config.sh"
+WORK_DIR="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+assert_eq() {
+    local expected="$1" actual="$2" label="$3"
+    [[ "$actual" == "$expected" ]] || fail "$label: expected '$expected', got '$actual'"
+}
+
+assert_file_eq() {
+    local expected="$1" file="$2" label="$3"
+    local actual
+    actual="$(cat "$file")"
+    [[ "$actual" == "$expected" ]] || fail "$label:
+--- expected ---
+$expected
+--- got ---
+$actual"
+}
+
+run_migrator() {
+    AIRPLANES_CONFIG_LOCK_HELD=1 "$MIGRATOR" "$@"
+}
+
+with_file() {
+    # with_file <name> <content>: writes content to $WORK_DIR/<name>
+    local name="$1"; shift
+    printf '%s' "$1" > "$WORK_DIR/$name"
+    printf '%s\n' "$WORK_DIR/$name"
+}
+
+test_version_flag() {
+    local out rc=0
+    out="$(run_migrator --version)" || rc=$?
+    assert_eq 0 "$rc" "--version exit code"
+    [[ "$out" == migrate-config.sh\ version=* ]] || fail "--version output: '$out'"
+    echo "PASS: --version"
+}
+
+test_simple_user_migrates() {
+    local f
+    f="$(with_file "case1" 'LATITUDE=51.5
+USER="alice"
+DUMP1090=yes
+')"
+    run_migrator "$f"
+    assert_file_eq 'LATITUDE=51.5
+USER="alice"
+MLAT_USER="alice"
+MLAT_ENABLED=true
+DUMP1090=yes' "$f" "USER=alice → split"
+    [[ -f "$f.pre-mlat-split" ]] || fail "backup not created"
+    echo "PASS: USER=alice migrates"
+}
+
+test_user_0_disables() {
+    local f
+    f="$(with_file "case2" 'USER=0
+LATITUDE=0
+')"
+    run_migrator "$f"
+    assert_file_eq 'USER="0"
+MLAT_USER=""
+MLAT_ENABLED=false
+LATITUDE=0' "$f" "USER=0 → disabled"
+    echo "PASS: USER=0 disables"
+}
+
+test_user_disable_keyword() {
+    local f
+    f="$(with_file "case3" 'USER=disable
+')"
+    run_migrator "$f"
+    assert_file_eq 'USER="disable"
+MLAT_USER=""
+MLAT_ENABLED=false' "$f" "USER=disable → disabled"
+    echo "PASS: USER=disable disables"
+}
+
+test_user_unquoted_normalized() {
+    local f
+    f="$(with_file "case4" 'USER=bob
+')"
+    run_migrator "$f"
+    assert_file_eq 'USER="bob"
+MLAT_USER="bob"
+MLAT_ENABLED=true' "$f" "unquoted USER gets normalized"
+    echo "PASS: unquoted USER normalized"
+}
+
+test_split_brain_user_wins() {
+    local f
+    f="$(with_file "case5" 'USER="alice"
+MLAT_USER="bob"
+MLAT_ENABLED=true
+')"
+    run_migrator "$f"
+    assert_file_eq 'USER="alice"
+MLAT_USER="alice"
+MLAT_ENABLED=true' "$f" "split-brain: USER authoritative"
+    echo "PASS: split-brain USER wins"
+}
+
+test_already_migrated_no_user() {
+    local f
+    f="$(with_file "case6" 'MLAT_USER="alice"
+MLAT_ENABLED=true
+DUMP1090=yes
+')"
+    local before_mtime after_mtime
+    before_mtime="$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f")"
+    sleep 1
+    run_migrator "$f"
+    after_mtime="$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f")"
+    assert_eq "$before_mtime" "$after_mtime" "already-migrated: mtime preserved"
+    [[ ! -f "$f.pre-mlat-split" ]] || fail "backup created on already-migrated file"
+    echo "PASS: already-migrated is no-op"
+}
+
+test_idempotent_second_run() {
+    local f
+    f="$(with_file "case7" 'USER="alice"
+')"
+    run_migrator "$f"
+    local first_content first_mtime
+    first_content="$(cat "$f")"
+    first_mtime="$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f")"
+    sleep 1
+    run_migrator "$f"
+    local second_content second_mtime
+    second_content="$(cat "$f")"
+    second_mtime="$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f")"
+    assert_eq "$first_content" "$second_content" "idempotent: content"
+    assert_eq "$first_mtime" "$second_mtime" "idempotent: mtime preserved"
+    echo "PASS: idempotent second run"
+}
+
+test_shell_metachars_escaped() {
+    local f
+    f="$(with_file "case8" 'USER="weird$X`bt`name"
+')"
+    run_migrator "$f"
+    # USER and MLAT_USER must both have shell metachars escaped.
+    grep -q 'USER="weird\\\$X\\`bt\\`name"' "$f" || fail "USER not escaped: $(cat "$f")"
+    grep -q 'MLAT_USER="weird\\\$X\\`bt\\`name"' "$f" || fail "MLAT_USER not escaped: $(cat "$f")"
+    echo "PASS: shell metachars escaped in both USER and MLAT_USER"
+}
+
+test_empty_user_degenerate() {
+    local f
+    f="$(with_file "case9" 'USER=""
+')"
+    run_migrator "$f"
+    assert_file_eq 'USER=""
+MLAT_USER=""
+MLAT_ENABLED=true' "$f" "USER='' → MLAT_USER='' MLAT_ENABLED=true"
+    echo "PASS: empty USER (degenerate) handled"
+}
+
+test_malformed_quote_rejected() {
+    local f rc=0
+    f="$(with_file "case10" 'USER="alice
+DUMP1090=yes
+')"
+    local before
+    before="$(cat "$f")"
+    run_migrator "$f" 2>/dev/null || rc=$?
+    [[ "$rc" -ne 0 ]] || fail "malformed double-quote not rejected"
+    assert_file_eq "$before" "$f" "malformed file unchanged"
+    echo "PASS: malformed double-quote rejected, file unchanged"
+}
+
+test_missing_file_is_noop() {
+    local f="$WORK_DIR/does-not-exist.txt"
+    local rc=0
+    run_migrator "$f" || rc=$?
+    assert_eq 0 "$rc" "missing file is no-op"
+    [[ ! -f "$f" ]] || fail "missing-file path was created"
+    echo "PASS: missing file is no-op"
+}
+
+test_backup_not_overwritten() {
+    local f
+    f="$(with_file "case11" 'USER="alice"
+')"
+    run_migrator "$f"
+    local backup_content_1
+    backup_content_1="$(cat "$f.pre-mlat-split")"
+    # Modify the live file via second migration (would re-derive)
+    # The backup must NOT be touched.
+    sleep 1
+    run_migrator "$f"
+    local backup_content_2
+    backup_content_2="$(cat "$f.pre-mlat-split")"
+    assert_eq "$backup_content_1" "$backup_content_2" "backup unchanged on subsequent runs"
+    echo "PASS: backup written once, never overwritten"
+}
+
+test_crlf_tolerated() {
+    local f="$WORK_DIR/case12"
+    printf 'LATITUDE=51.5\r\nUSER="alice"\r\nDUMP1090=yes\r\n' > "$f"
+    run_migrator "$f"
+    grep -q '^MLAT_USER="alice"$' "$f" || fail "CRLF source not migrated: $(cat "$f")"
+    grep -q '^MLAT_ENABLED=true$' "$f" || fail "CRLF: MLAT_ENABLED missing: $(cat "$f")"
+    echo "PASS: CRLF tolerated"
+}
+
+main() {
+    test_version_flag
+    test_simple_user_migrates
+    test_user_0_disables
+    test_user_disable_keyword
+    test_user_unquoted_normalized
+    test_split_brain_user_wins
+    test_already_migrated_no_user
+    test_idempotent_second_run
+    test_shell_metachars_escaped
+    test_empty_user_degenerate
+    test_malformed_quote_rejected
+    test_missing_file_is_noop
+    test_backup_not_overwritten
+    test_crlf_tolerated
+    echo "All migrate-config tests passed"
+}
+
+main "$@"

--- a/test/migrate-config-test.sh
+++ b/test/migrate-config-test.sh
@@ -161,15 +161,15 @@ test_shell_metachars_escaped() {
     echo "PASS: shell metachars escaped in both USER and MLAT_USER"
 }
 
-test_empty_user_degenerate() {
+test_empty_user_defaults_anonymous() {
     local f
     f="$(with_file "case9" 'USER=""
 ')"
     run_migrator "$f"
     assert_file_eq 'USER=""
-MLAT_USER=""
-MLAT_ENABLED=true' "$f" "USER='' → MLAT_USER='' MLAT_ENABLED=true"
-    echo "PASS: empty USER (degenerate) handled"
+MLAT_USER="Anonymous"
+MLAT_ENABLED=true' "$f" "USER='' → MLAT_USER='Anonymous' MLAT_ENABLED=true"
+    echo "PASS: empty USER defaults MLAT_USER to Anonymous"
 }
 
 test_malformed_quote_rejected() {
@@ -230,7 +230,7 @@ main() {
     test_already_migrated_no_user
     test_idempotent_second_run
     test_shell_metachars_escaped
-    test_empty_user_degenerate
+    test_empty_user_defaults_anonymous
     test_malformed_quote_rejected
     test_missing_file_is_noop
     test_backup_not_overwritten

--- a/update-webconfig.sh
+++ b/update-webconfig.sh
@@ -38,7 +38,7 @@ bash install.sh dont_reset_config
 cd /tmp
 rm -rf "$updir"
 
-echo "8.3.$(date '+%y%m%d')" > /boot/airplanes-version-webconfig
+echo "8.4.$(date '+%y%m%d')" > /boot/airplanes-version-webconfig
 
 echo '--------------------------------------------'
 echo '        update-webconfig complete.          '


### PR DESCRIPTION
Adds a migrator script that translates the legacy single-key USER= form in airplanes-config.txt into the split MLAT_USER + MLAT_ENABLED keys expected by newer feed daemons. The migrator runs once at install time and after every PHP-driven save (through install-adsbconfig.sh). install-adsbconfig.sh and restart-services.sh share a flock so a service restart can never read a partially-written or half-migrated file.

USER is preserved in normalized quoted form alongside the new keys, so existing legacy daemons and helpers that still key off USER keep working. Migration is idempotent (byte-compares before rewriting, so mtime stays put on no-op re-runs), atomic (temp + mv), parses without sourcing user content, and writes a one-time .pre-mlat-split backup. Covered by a 14-case bash test suite that's wired into the existing CI shellcheck + tests job.