### PR TITLE
Let stable legacy updates resolve feed release tags

### DIFF
--- a/helpers/update-channel.sh
+++ b/helpers/update-channel.sh
@@ -37,7 +37,10 @@ airplanes_webconfig_apply_channel_defaults() {
         *)
             channel="main"
             update_branch="main"
-            feed_branch="main"
+            # Stable legacy-image updates must not pin feed/main here.
+            # Leaving AIRPLANES_FEED_BRANCH empty lets airplanes-update's
+            # tag-aware bridge resolve the latest stable feed release tag.
+            feed_branch=""
             webconfig_branch="master"
             ;;
     esac

--- a/test/update-channel-test.sh
+++ b/test/update-channel-test.sh
@@ -62,7 +62,7 @@ assert_dev_defaults() {
 assert_main_defaults() {
     assert_eq "main" "$AIRPLANES_CHANNEL" "channel"
     assert_eq "main" "$AIRPLANES_UPDATE_BRANCH" "update branch"
-    assert_eq "main" "$AIRPLANES_FEED_BRANCH" "feed branch"
+    assert_eq "" "$AIRPLANES_FEED_BRANCH" "feed branch"
     assert_eq "master" "$AIRPLANES_WEBCONFIG_BRANCH" "webconfig branch"
     assert_eq "https://raw.githubusercontent.com/airplanes-live/airplanes-update/main/update-airplanes.sh" \
         "$(airplanes_update_script_url)" "update raw URL"


### PR DESCRIPTION
## Summary
- stop defaulting stable/main legacy webconfig updates to `AIRPLANES_FEED_BRANCH=main`
- leave the feed branch override empty on stable/main so airplanes-update's tag-aware bridge can resolve the latest stable feed release tag
- keep dev behavior pinned to `AIRPLANES_FEED_BRANCH=dev` for test/dev channel use

## Testing
- `bash -n helpers/update-channel.sh`
- `bash -n helpers/bg-update.sh`
- `bash -n test/update-channel-test.sh`
- `bash test/update-channel-test.sh`
- `shellcheck helpers/update-channel.sh helpers/bg-update.sh test/update-channel-test.sh`