### PR TITLE
Invoke bg-update via bash so bookworm noexec on runtime tmpfs does not block updates

### DIFF
--- a/helpers/run-update.sh
+++ b/helpers/run-update.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 set -e
 
+# /run is mounted noexec on bookworm by default (it was exec-allowed on
+# bullseye), so executing /run/bg-update.sh directly fails with
+# `Permission denied` on the 2025 Pi-OS fleet. Invoke via /bin/bash so
+# the noexec mount option does not block — bash itself is the binary
+# being exec'd, and bg-update.sh just needs to be readable.
 rm -f /run/bg-update.sh
 cp /airplanes/webconfig/helpers/bg-update.sh /run/bg-update.sh
 
-systemd-run --on-active=3 /run/bg-update.sh
+systemd-run --on-active=3 /bin/bash /run/bg-update.sh
 
 sleep 1
 exit


### PR DESCRIPTION
On bookworm (Debian 12, the current and 2025 Pi-OS-based feeder image base), the runtime tmpfs is mounted noexec by default. `run-update.sh` copies bg-update.sh to that tmpfs and asks systemd-run to execute it directly, which fails with `Permission denied` — the Update Feeder button is unusable on the entire bookworm-based fleet.

Invoke bg-update.sh via bash so the noexec mount option does not apply; the script only needs to be readable. Bullseye is unaffected (its runtime tmpfs is exec-allowed by default).

Reproduced on a 2025 image; same flow runs cleanly on a bullseye 2023 image.